### PR TITLE
Make users not have to depend on `include_dir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ Press escape to switch between the game and the editor.
 - [ ] Modify editor W, A, S, D key short cuts (shift sprite) to use arrow keys
 - [ ] Implement sprite editor tools: line, circle, selection tool, zoom, etc
 - [ ] Finish porting the pico8 API (missing functions like `peek`, `poke`, `circ`, etc)
-- [ ] Building/packaging your game as a single file.
-      Currently the library stores your assets (sprite sheet, map, sprite flags (and sound in the future))
-      in separate files, and the application loads them at runtime.
-      It'd be cool to have a way to bundle all the code and assets together in a single executable file for ease of distribution.
-      This should also facilitate using wasm.
-- [ ] Wasm support
 - [ ] Add a concept of "active widget" in the sprite editor.
       If you're click-dragging the mouse in the color picker, moving the mouse away will trigger interactions in other components, this is wrong
 - [ ] Some rudimentary console-like thing like in Pico8 (to run graphic commands, etc)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 runty8 = { path = "../src/runty8" }
 runty8-core = { path = "../src/runty8-core" }
 log = "0.4"
-include_dir= "0.7.3"
 
 [[bin]]
 name = "celeste"

--- a/src/runty8-core/src/lib.rs
+++ b/src/runty8-core/src/lib.rs
@@ -207,9 +207,11 @@ pub enum Event {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! include_dir_hack {
-    (#[doc = $arg:tt]) => {
-        include_dir::include_dir!($arg);
-    };
+    (#[doc = $arg:tt]) => {{
+        use $crate::include_dir;
+
+        include_dir::include_dir!($arg)
+    }};
 }
 
 #[doc(hidden)]
@@ -222,6 +224,9 @@ macro_rules! include_assets {
     };
 }
 
+#[doc(hidden)]
+pub use include_dir;
+#[doc(hidden)]
 pub use paste::paste;
 /// Embed game assets in your binary
 
@@ -248,6 +253,7 @@ pub fn create_asset<T: Default>(
 #[macro_export]
 macro_rules! load_assets {
     ($path:tt) => {{
+        use $crate::include_dir;
         static DIR: include_dir::Dir = $crate::include_assets!($path);
 
         (|| {

--- a/src/runty8/src/lib.rs
+++ b/src/runty8/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+
 //! Entrypoints for all games using runty8.
 
 #[doc(inline)]


### PR DESCRIPTION
Users used to have to have a dependency on `include_dir` to be able to use `runty8::load_assets!`.
See: https://github.com/Michael-F-Bryan/include_dir/issues/87.