### PR TITLE
Adding pico8's flr function

### DIFF
--- a/src/runty8-core/src/pico8.rs
+++ b/src/runty8-core/src/pico8.rs
@@ -233,7 +233,7 @@ pub fn flr(num: f32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{mid, rnd, sin};
+    use super::{mid, rnd, sin, flr};
 
     macro_rules! assert_delta {
         ($x:expr, $y:expr, $d:expr) => {

--- a/src/runty8-core/src/pico8.rs
+++ b/src/runty8-core/src/pico8.rs
@@ -226,6 +226,11 @@ pub fn mid(first: f32, second: f32, third: f32) -> f32 {
     slice[1]
 }
 
+/// Pico8's [`flr`](<https://pico-8.fandom.com/wiki/Flr>) function.
+pub fn flr(num: f32) -> i32 {
+    num.floor() as i32
+}
+
 #[cfg(test)]
 mod tests {
     use super::{mid, rnd, sin};
@@ -265,5 +270,13 @@ mod tests {
         assert_delta!(mid(8.0, 2.0, 4.0), 4.0, 0.00001);
         assert_delta!(mid(-3.5, -3.4, -3.6), -3.5, 0.00001);
         assert_delta!(mid(6.0, 6.0, 8.0), 6.0, 0.00001);
+    }
+
+    #[test]
+    fn flr_works() {
+        assert_eq!(flr(5.9), 5);
+        assert_eq!(flr(-5.2), -6);
+        assert_eq!(flr(7.0), 7);
+        assert_eq!(flr(-7.0), -7);
     }
 }

--- a/src/runty8-core/src/pico8.rs
+++ b/src/runty8-core/src/pico8.rs
@@ -233,7 +233,7 @@ pub fn flr(num: f32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{mid, rnd, sin, flr};
+    use super::{flr, mid, rnd, sin};
 
     macro_rules! assert_delta {
         ($x:expr, $y:expr, $d:expr) => {

--- a/src/runty8/src/lib.rs
+++ b/src/runty8/src/lib.rs
@@ -3,7 +3,7 @@
 //! Entrypoints for all games using runty8.
 
 #[doc(inline)]
-pub use runty8_core::{load_assets, mid, rnd, sin, flr, App, Button, Pico8};
+pub use runty8_core::{flr, load_assets, mid, rnd, sin, App, Button, Pico8};
 
 use runty8_core::Resources;
 

--- a/src/runty8/src/lib.rs
+++ b/src/runty8/src/lib.rs
@@ -3,7 +3,7 @@
 //! Entrypoints for all games using runty8.
 
 #[doc(inline)]
-pub use runty8_core::{load_assets, mid, rnd, sin, App, Button, Pico8};
+pub use runty8_core::{load_assets, mid, rnd, sin, flr, App, Button, Pico8};
 
 use runty8_core::Resources;
 


### PR DESCRIPTION
*Issue #30 if available:*

*Description of changes:*
I added pico8's flr function and some tests for it. It uses standard floor() rust function, but return type is i32

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
