### PR TITLE
Run CI on (external) pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 name: Continuous integration
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 name: Continuous integration
 


### PR DESCRIPTION
## Description

CI was not running for community-submitted PRs (See https://github.com/jjant/runty8/pull/40, https://github.com/jjant/runty8/pull/42). This should fix it.


-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
