### PR TITLE
renamed to cross/circle

### DIFF
--- a/examples/bresenham/main.rs
+++ b/examples/bresenham/main.rs
@@ -35,11 +35,11 @@ impl App for MyThing {
             self.center_x -= 1;
         }
 
-        if state.btn(Button::X) {
+        if state.btn(Button::Cross) {
             self.radius -= 1;
             self.radius = self.radius.max(0);
         }
-        if state.btn(Button::C) {
+        if state.btn(Button::Circle) {
             self.radius += 1;
         }
     }

--- a/examples/celeste/main.rs
+++ b/examples/celeste/main.rs
@@ -482,8 +482,8 @@ const K_LEFT: Button = Button::Left;
 const K_RIGHT: Button = Button::Right;
 const K_UP: Button = Button::Up;
 const K_DOWN: Button = Button::Down;
-const K_JUMP: Button = Button::C;
-const K_DASH: Button = Button::X;
+const K_JUMP: Button = Button::Circle;
+const K_DASH: Button = Button::Cross;
 
 fn title_screen(game_state: &mut GameState, pico8: &Pico8) {
     game_state.got_fruit = vec![false; 30];

--- a/examples/celeste/main.rs
+++ b/examples/celeste/main.rs
@@ -51,7 +51,6 @@ impl App for GameState {
         pico8.set_title("Celeste".to_owned());
 
         let clouds = (0..=16)
-            .into_iter()
             .map(|_| Cloud {
                 x: rnd(128.),
                 y: rnd(128.),
@@ -61,7 +60,6 @@ impl App for GameState {
             .collect();
 
         let particles = (0..=24)
-            .into_iter()
             .map(|_| Particle {
                 x: rnd(128.),
                 y: rnd(128.),

--- a/examples/moving-box/main.rs
+++ b/examples/moving-box/main.rs
@@ -83,7 +83,7 @@ impl App for ExampleApp {
             self.xa += 10;
         }
 
-        if state.btn(Button::C) && self.yc == 0 {
+        if state.btn(Button::Circle) && self.yc == 0 {
             self.ya = -200;
             self.yc = 39;
         }

--- a/src/runty8-core/src/input.rs
+++ b/src/runty8-core/src/input.rs
@@ -56,8 +56,8 @@ impl Input {
 
     fn button_to_ref(&mut self, button: Button) -> &mut Option<bool> {
         match button {
-            Button::X => &mut self.x,
-            Button::C => &mut self.c,
+            Button::Cross => &mut self.x,
+            Button::Circle => &mut self.c,
             Button::Left => &mut self.left,
             Button::Right => &mut self.right,
             Button::Up => &mut self.up,
@@ -69,8 +69,8 @@ impl Input {
 
 fn key_to_button(key: Key) -> Option<Button> {
     match key {
-        Key::X => Some(Button::X),
-        Key::C => Some(Button::C),
+        Key::X => Some(Button::Cross),
+        Key::C => Some(Button::Circle),
         Key::LeftArrow => Some(Button::Left),
         Key::RightArrow => Some(Button::Right),
         Key::UpArrow => Some(Button::Up),

--- a/src/runty8-core/src/lib.rs
+++ b/src/runty8-core/src/lib.rs
@@ -45,9 +45,9 @@ pub enum Button {
     /// Down arrow.
     Down,
     /// X key.
-    X,
+    Cross,
     /// C key.
-    C,
+    Circle,
     /// Left mouse button.
     Mouse,
 }

--- a/src/runty8-core/src/state.rs
+++ b/src/runty8-core/src/state.rs
@@ -54,8 +54,8 @@ impl State {
             Button::Right => &self.right,
             Button::Up => &self.up,
             Button::Down => &self.down,
-            Button::X => &self.x,
-            Button::C => &self.c,
+            Button::Cross => &self.x,
+            Button::Circle => &self.c,
             Button::Mouse => &self.mouse_pressed,
         }
     }


### PR DESCRIPTION
*Issue #, if available:* [#45](https://github.com/jjant/runty8/issues/45)

*Description of changes:* Just went ahead and changed the names for clarity, `cargo check --all-targets` is too good!

I didn't touch `Z`, `V`, `N` and `M` that act as `Cross` and `Circle` as I'm not even sure why pico-8 decided to map them multiple times, since with multiplayer it has even more keys bound to them I think? We can close my issue and you can track this elsewhere if you want?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
