### PR TITLE
Add `util::min_max` function and fix bug in `rectfill`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.63.0 # Current rustc on my machine
+          - 1.65.0 # MSRV
         target:
           - x86_64-unknown-linux-gnu
           - wasm32-unknown-unknown

--- a/src/runty8-core/src/draw_data.rs
+++ b/src/runty8-core/src/draw_data.rs
@@ -1,6 +1,7 @@
 use crate::flags::Flags;
 use crate::map::Map;
 use crate::sprite_sheet::SpriteSheet;
+use crate::util::{min_max, MinMax};
 use crate::Color;
 use crate::{draw, font};
 
@@ -148,6 +149,7 @@ impl DrawData {
     }
 
     pub(crate) fn rectfill(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, color: Color) {
+        let MinMax { min: y0, max: y1 } = min_max(y0, y1);
         for y in y0..=y1 {
             self.line(x0, y, x1, y, color);
         }

--- a/src/runty8-core/src/draw_data.rs
+++ b/src/runty8-core/src/draw_data.rs
@@ -10,6 +10,7 @@ use crate::sprite_sheet::Sprite;
 const WIDTH: usize = 128;
 const NUM_COMPONENTS: usize = 3;
 
+/// A raw buffer made up of `RGB` components: [R, G, B, R, G, B, ...].
 type Buffer = [u8; NUM_COMPONENTS * WIDTH * WIDTH];
 const BLACK_BUFFER: Buffer = [0; NUM_COMPONENTS * WIDTH * WIDTH];
 
@@ -150,6 +151,7 @@ impl DrawData {
 
     pub(crate) fn rectfill(&mut self, x0: i32, y0: i32, x1: i32, y1: i32, color: Color) {
         let MinMax { min: y0, max: y1 } = min_max(y0, y1);
+
         for y in y0..=y1 {
             self.line(x0, y, x1, y, color);
         }
@@ -349,4 +351,100 @@ pub mod colors {
     pub const LAVENDER: Color = 13;
     pub const PINK: Color = 14;
     pub const LIGHT_PEACH: Color = 15;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        colors,
+        draw_data::{get_color, Buffer, NUM_COMPONENTS},
+    };
+
+    use super::DrawData;
+
+    #[derive(Clone)]
+    enum IterBothNextYield {
+        AThenB,
+        BThenA,
+        Done,
+    }
+
+    #[derive(Clone)]
+    struct IterBoth<T> {
+        a: T,
+        b: T,
+        yield_state: IterBothNextYield,
+    }
+
+    impl<T> IterBoth<T> {
+        fn new(a: T, b: T) -> Self {
+            Self {
+                a,
+                b,
+                yield_state: IterBothNextYield::AThenB,
+            }
+        }
+    }
+
+    impl<T: Copy> Iterator for IterBoth<T> {
+        type Item = (T, T);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.yield_state {
+                IterBothNextYield::AThenB => {
+                    self.yield_state = IterBothNextYield::BThenA;
+                    Some((self.a, self.b))
+                }
+                IterBothNextYield::BThenA => {
+                    self.yield_state = IterBothNextYield::Done;
+                    Some((self.b, self.a))
+                }
+                IterBothNextYield::Done => None,
+            }
+        }
+    }
+
+    #[test]
+    fn rectfill_works_with_unordered_arguments() {
+        fn red_pixels_count(buf: &Buffer) -> usize {
+            fn is_red(chunk: &[u8]) -> bool {
+                let chunk: Vec<u32> = chunk
+                    .into_iter()
+                    .copied()
+                    .map(|component| component as u32)
+                    .collect();
+                let (r, g, b) = (chunk[0], chunk[1], chunk[2]);
+
+                let color = r << 16 | g << 8 | b;
+
+                color == get_color(colors::RED)
+            }
+
+            buf.chunks(NUM_COMPONENTS)
+                .filter(|chunk| is_red(chunk))
+                .count()
+        }
+
+        let x = IterBoth::new(10, 25);
+        let y = IterBoth::new(5, 30);
+
+        for (x0, x1) in x {
+            for (y0, y1) in y.clone() {
+                let mut draw_data = DrawData::new();
+
+                // No pixels are red before the `rectfill` call.
+                assert_eq!(red_pixels_count(draw_data.buffer()), 0);
+
+                draw_data.rectfill(x0, y0, x1, y1, colors::RED);
+                let width = (x1 - x0).abs() + 1;
+                let height = (y1 - y0).abs() + 1;
+                let rect_size_in_pixels = width * height;
+
+                assert_eq!(
+                    red_pixels_count(draw_data.buffer()),
+                    rect_size_in_pixels as usize
+                );
+            }
+        }
+    }
 }

--- a/src/runty8-core/src/lib.rs
+++ b/src/runty8-core/src/lib.rs
@@ -10,6 +10,7 @@ mod pico8;
 pub mod serialize;
 mod sprite_sheet;
 mod state;
+pub(crate) mod util;
 pub use draw_data::colors;
 
 pub mod draw;

--- a/src/runty8-core/src/util.rs
+++ b/src/runty8-core/src/util.rs
@@ -1,0 +1,25 @@
+#[derive(Debug)]
+pub(crate) struct MinMax<T> {
+    pub(crate) min: T,
+    pub(crate) max: T,
+}
+
+pub(crate) fn min_max<T: Ord>(a: T, b: T) -> MinMax<T> {
+    if a < b {
+        MinMax { min: a, max: b }
+    } else {
+        MinMax { min: b, max: a }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{min_max, MinMax};
+
+    #[test]
+    fn min_max_works() {
+        assert!(matches!(min_max(2, 3), MinMax { min: 2, max: 3 }));
+        assert!(matches!(min_max(3, 2), MinMax { min: 2, max: 3 }));
+        assert!(matches!(min_max(0, 0), MinMax { min: 0, max: 0 }));
+    }
+}


### PR DESCRIPTION
## Description

Previously, `Pico8::rectfill` would require the `y0, y1` arguments to be in increasing order (e.g, `y0 = 5, y1 = 10`), and would print nothing if that wasn't the case. This was different than in `Pico8`, and fixed in this commit.

**Also updates MSRV to 1.65.0** to make CI compile.
-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
