### PR TITLE
Relax `Copy` requirement on `KeyCombo`

### DIFF
--- a/src/runty8-editor/src/editor.rs
+++ b/src/runty8-editor/src/editor.rs
@@ -112,7 +112,7 @@ impl Editor {
     fn handle_key_combos(&mut self, key_event: KeyboardEvent, resources: &mut Resources) {
         self.key_combos.on_event(key_event, |action| {
             handle_key_combo(
-                action,
+                *action,
                 self.selected_sprite,
                 &mut self.notification,
                 &mut self.clipboard,

--- a/src/runty8-editor/src/editor/key_combo.rs
+++ b/src/runty8-editor/src/editor/key_combo.rs
@@ -20,8 +20,8 @@ impl<Id> KeyCombos<Id> {
     }
 }
 
-impl<Id: Copy> KeyCombos<Id> {
-    pub fn on_event(&mut self, key_event: KeyboardEvent, mut on_combo: impl FnMut(Id)) {
+impl<Id> KeyCombos<Id> {
+    pub fn on_event(&mut self, key_event: KeyboardEvent, mut on_combo: impl FnMut(&Id)) {
         let mut handled = false;
 
         for key_combo in self.key_combos.iter_mut() {
@@ -73,10 +73,10 @@ impl<Id> KeyCombo<Id> {
     }
 }
 
-impl<Id: Copy> KeyCombo<Id> {
-    fn key_down(&mut self, key: Key) -> Option<Id> {
+impl<Id> KeyCombo<Id> {
+    fn key_down(&mut self, key: Key) -> Option<&Id> {
         if key == self.action_key && self.modifiers_pressed() {
-            return Some(self.id);
+            return Some(&self.id);
         }
 
         let entry = self.modifiers.entry(key);


### PR DESCRIPTION
## Description

`KeyCombo`'s methods need not require `Copy`.


-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
