### PR TITLE
Fix mouse position not getting updated in the editor

### DIFF
--- a/src/runty8-editor/src/controller.rs
+++ b/src/runty8-editor/src/controller.rs
@@ -78,6 +78,12 @@ impl<Game: AppCompat> Controller<Game> {
             &Msg::KeyboardEvent(event) => {
                 self.handle_key_combos(event);
             }
+            // Currently the mouse position is tracked by two things independently:
+            //   - Updated by this subscription here in the controller, stored in `self.mouse_position`
+            //   - Updated by the Game, stored in the controller as well, in `self.pico8.state.mouse_{x,y}`
+            //
+            // I haven't found yet a nice way to unify them that plays nicely with both,
+            // and can be run in the editor or in the runtime by itself.
             &Msg::MouseEvent(MouseEvent::Move { x, y }) => {
                 self.mouse_position = Vec2i::new(x, y);
             }

--- a/src/runty8-editor/src/util/vec2.rs
+++ b/src/runty8-editor/src/util/vec2.rs
@@ -47,8 +47,14 @@ impl<T: Neg> Neg for Vec2<T> {
 
 pub(crate) type Vec2i = Vec2<i32>;
 
+impl<T> Vec2<T> {
+    pub fn new(x: T, y: T) -> Self {
+        Self { x, y }
+    }
+}
+
 pub(crate) fn vec2<T>(x: T, y: T) -> Vec2<T> {
-    Vec2 { x, y }
+    Vec2::new(x, y)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

In #73, while trying to make running games the editor consistent with running them standalone in the runtime, I accidentally made the editor not update the cursor on mouse move events.

Here, I've put in a workaround (hopefully a temporary solution) to fix this, by keeping track of the cursor position both in the game and in the top-level controller.


-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
